### PR TITLE
Ability to continue training saved models

### DIFF
--- a/train.py
+++ b/train.py
@@ -34,7 +34,7 @@ parser.add_argument('--style_image', '-s', type=str, required=True,
 parser.add_argument('--batchsize', '-b', type=int, default=1,
                     help='batch size (default value is 1)')
 parser.add_argument('--input', '-i', default=None, type=str,
-                    help='input model file path without extension')
+                    help='path to input model file')
 parser.add_argument('--output', '-o', default='out', type=str,
                     help='output model file path without extension')
 parser.add_argument('--lambda_tv', default=10e-4, type=float,

--- a/train.py
+++ b/train.py
@@ -1,5 +1,5 @@
 import numpy as np
-import os
+import os, re
 import argparse
 from PIL import Image
 
@@ -48,6 +48,7 @@ args = parser.parse_args()
 
 batchsize = args.batchsize
 
+m_epoch = 0
 n_epoch = args.epoch
 lambda_tv = args.lambda_tv
 lambda_f = args.lambda_feat
@@ -68,6 +69,11 @@ print n_iter, 'iterations,', n_epoch, 'epochs'
 model = FastStyleNet()
 vgg = VGG()
 serializers.load_npz('vgg16.model', vgg)
+if args.input:
+    serializers.load_npz(args.input, model)
+    m_epoch = re.search('\d+', os.path.basename(args.input))
+    m_epoch = int(m_epoch.group(0))+1 if m_epoch else 1
+    print '{} loaded, {} epochs done'.format(args.input, m_epoch)
 if args.gpu >= 0:
     cuda.get_device(args.gpu).use()
     model.to_gpu()
@@ -85,7 +91,7 @@ for i in range(batchsize):
 feature_s = vgg(Variable(style_b, volatile=True))
 gram_s = [gram_matrix(y) for y in feature_s]
 
-for epoch in range(n_epoch):
+for epoch in range(m_epoch, n_epoch):
     print 'epoch', epoch
     for i in range(n_iter):
         model.zerograds()

--- a/train.py
+++ b/train.py
@@ -91,7 +91,7 @@ for i in range(batchsize):
 feature_s = vgg(Variable(style_b, volatile=True))
 gram_s = [gram_matrix(y) for y in feature_s]
 
-for epoch in range(m_epoch, n_epoch):
+for epoch in range(m_epoch, m_epoch+n_epoch):
     print 'epoch', epoch
     for i in range(n_iter):
         model.zerograds()


### PR DESCRIPTION
Hey, thanks for the implementation. Great project, has a lot of potential.

I noticed train.py allows you to provide an input model with `-i` argument to train it further. However, it appears to be not implemented anywhere in the code except for argparse. I made an update to allow for model augmenting. Please review my changes and make your corrections if necessary.

Maybe there's a better way to determine starting epoch number, since reading it from a filename is not reliable. Perhaps there's some sort of embedded metadata in the model itself, that contains this info? Or passing it explicitly as a param would be better?

Thanks